### PR TITLE
Client Extensions API Example Enhancements

### DIFF
--- a/src/html/app.html
+++ b/src/html/app.html
@@ -22,19 +22,30 @@ under the License.
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Hello App - App</title>
+    <title>Hello World App - View</title>
+
+    <!-- Include Symphony's stylesheet -->
+    <link rel="stylesheet" type="text/css" href="https://symphony.com/resources/api/v1.1/symphony-style.css">
 </head>
-<style>
-    html {  background: #ffffff;  }
-</style>
-<body>
-    <h1>Welcome to the Hello Application!</h1>
 
-    <button id="increment">Increment unread count</button>
+<!-- 
+Add the "symphony-external-app" class to the body.
+See app.js for how the user's theme (light or dark) and font size (large, normal, small, xsmall) are detected and applied.
+-->
+<body class="symphony-external-app">
+    <h1>Hello World!</h1>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 
-    <div id="cashtag"></div>
+    <!-- Add the appropriate classes to buttons -->
+    <button id="increment" class="button primary">Increment Unread Badge Count</button>
 
+    <input type="text" class="text-input" id="cashtag" placeholder="Cashtag">
+
+    <!-- <div id="cashtag"></div> -->
+
+    <!-- Include Symphony's Client Extension API javascript -->
     <script type="text/javascript" src="https://www.symphony.com/resources/api/v1.0/symphony-api.js" charset="utf-8"></script>
+    <!-- Include the app view javascript -->
     <script type="text/javascript" src="app.bundle.js" charset="utf-8"></script>
 </body>
 </html>

--- a/src/html/app.html
+++ b/src/html/app.html
@@ -26,6 +26,25 @@ under the License.
 
     <!-- Include Symphony's stylesheet -->
     <link rel="stylesheet" type="text/css" href="https://symphony.com/resources/api/v1.1/symphony-style.css">
+
+    <style>
+    	.hidden {
+    		display: none;
+    	}
+
+    	#article-blurb {
+    		line-height: 1.5;
+    	}
+
+    	#article-subtitle {
+    		font-style: italic;
+    		font-weight: bold;
+    	}
+
+    	.text-input {
+    		width: 200px;
+    	}
+    </style>
 </head>
 
 <!-- 
@@ -34,14 +53,33 @@ See app.js for how the user's theme (light or dark) and font size (large, normal
 -->
 <body class="symphony-external-app">
     <h1>Hello World!</h1>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 
     <!-- Add the appropriate classes to buttons -->
     <button id="increment" class="button primary">Increment Unread Badge Count</button>
 
+    <!-- This textbox will be replaced with a cashtag when the app is launched from a cashtag. -->
     <input type="text" class="text-input" id="cashtag" placeholder="Cashtag">
 
-    <!-- <div id="cashtag"></div> -->
+    <!-- This textbox will be replaced with an articleId when the app is launched from an article. -->
+    <input type="text" class="text-input" id="article" placeholder="Article">
+
+    <!-- These are the contents of an article that can be shared by clicking the share button. -->
+    <div>
+    	<h2 id="article-title">Symphony Launches Mobile App</h2>
+    	<p id="article-subtitle">Application is mobile device management (MDM) compatible.</p>
+    	<p id="article-blurb">Symphony Communication Services, a Palo Alto, Calif.-based messaging startup, announced its enterprise-ready mobile app for Apple iPhone is now available for download.</p>
+    	<p id="article-author">Dan DeFrancesco</p>
+    	<p id="article-date">07 June 2016</p>
+    	<p id="article-id" class="hidden">symphony-article</p>
+    	<!-- @TODO(anjana): Change this to use the share icon rather than button. -->
+    	<button id="share" class="button primary">Share</button>
+    </div>
+    
+    <!-- This div will be displayed when the About this App menu item is clicked. -->
+    <div id="about-hello-world-app" class="hidden">
+    	<h2>About this App</h2>
+    	<p>This is a simple demo app.</p>
+    </div>
 
     <!-- Include Symphony's Client Extension API javascript -->
     <script type="text/javascript" src="https://www.symphony.com/resources/api/v1.0/symphony-api.js" charset="utf-8"></script>

--- a/src/html/app.html
+++ b/src/html/app.html
@@ -41,27 +41,26 @@ under the License.
     		font-weight: bold;
     	}
 
-    	.text-input {
-    		width: 200px;
+    	.module-text-input {
+    		width: 200px !important;
     	}
     </style>
 </head>
 
 <!-- 
-Add the "symphony-external-app" class to the body.
 See app.js for how the user's theme (light or dark) and font size (large, normal, small, xsmall) are detected and applied.
 -->
-<body class="symphony-external-app">
+<body>
     <h1>Hello World!</h1>
 
     <!-- Add the appropriate classes to buttons -->
     <button id="increment" class="button primary">Increment Unread Badge Count</button>
 
     <!-- This textbox will be replaced with a cashtag when the app is launched from a cashtag. -->
-    <input type="text" class="text-input" id="cashtag" placeholder="Cashtag">
+    <input type="text" class="text-input module-text-input" id="cashtag" placeholder="Cashtag">
 
     <!-- This textbox will be replaced with an articleId when the app is launched from an article. -->
-    <input type="text" class="text-input" id="article" placeholder="Article">
+    <input type="text" class="text-input module-text-input" id="article" placeholder="Article">
 
     <!-- These are the contents of an article that can be shared by clicking the share button. -->
     <div>

--- a/src/html/controller.html
+++ b/src/html/controller.html
@@ -22,11 +22,12 @@ under the License.
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Hello App - Controller</title>
+    <title>Hello World App - Controller</title>
 </head>
 <body>
-    <!--this is the controller, which runs as a persistent iFrame, out of the users view-->
+    <!-- This is the controller, which runs as a persistent iFrame, out of the user's view -->
     <script type="text/javascript" src="https://www.symphony.com/resources/api/v1.0/symphony-api.js" charset="utf-8"></script>
+    <!-- Include the app controller javascript -->
     <script type="text/javascript" src="controller.bundle.js" charset="utf-8"></script>
 </body>
 </html>

--- a/src/html/controller.html
+++ b/src/html/controller.html
@@ -19,13 +19,15 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<!-- This is the controller, which runs as a persistent iFrame, out of the user's view -->
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Hello World App - Controller</title>
 </head>
 <body>
-    <!-- This is the controller, which runs as a persistent iFrame, out of the user's view -->
+    
+    <!-- Include the Symphony Client Extensions API javascript -->
     <script type="text/javascript" src="https://www.symphony.com/resources/api/v1.0/symphony-api.js" charset="utf-8"></script>
     <!-- Include the app controller javascript -->
     <script type="text/javascript" src="controller.bundle.js" charset="utf-8"></script>

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -17,13 +17,18 @@
 * under the License.
 **/
 
+// Create our own local service pertaining to the application module
+// We have namespaced local services with "hello:"
+var helloAppService = SYMPHONY.services.register("hello:app");
+
 SYMPHONY.remote.hello().then(function(data) {
 
+    // Set the theme of the app module
     var themeColor = data.themeV2.name;
     var themeSize = data.themeV2.size;
     document.body.className += " " + themeColor + " " + themeSize;
 
-    SYMPHONY.application.connect("hello", ["modules", "applications-nav", "ui", "share"], ["hello:module"]).then(function(response) {
+    SYMPHONY.application.connect("hello", ["modules", "applications-nav", "ui", "share"], ["hello:app"]).then(function(response) {
 
         // The userReferenceId is an anonymized random string that can be used for uniquely identifying users.
         // The userReferenceId persists until the application is uninstalled by the user. 
@@ -36,16 +41,32 @@ SYMPHONY.remote.hello().then(function(data) {
         var uiService = SYMPHONY.services.subscribe("ui");
         var shareService = SYMPHONY.services.subscribe("share");
 
-        // Subscribe to our own local service
-        var controllerService = SYMPHONY.services.subscribe('hello:controller');
+        // MODULE: Add a menu item to our module
+        modulesService.addMenuItem("hello", "About Hello World App", "hello-menu-item");
+        modulesService.setHandler("hello", "hello:app");
 
         // LEFT NAV: Update the left navigation item's badge count when the "Increment Unread Badge Count" button is clicked using the navService's count method.
-        var button = document.getElementById("increment");
+        var incrementButton = document.getElementById("increment");
         var count = 0;
         // Bind a click event handler
-        button.addEventListener("click", function(){
+        incrementButton.addEventListener("click", function(){
             count++;
             navService.count("hello-nav", count);
+        });
+
+        // SHARE: Trigger Symphony's share modal when the "Share" button is clicked
+        var shareButton = document.getElementById("share");
+        var articleOptions = {
+            "title": document.getElementById("article-title").innerHTML,
+            "subTitle": document.getElementById("article-subtitle").innerHTML,
+            "blurb": document.getElementById("article-blurb").innerHTML,
+            "id": document.getElementById("article-id").innerHTML               
+        };
+        shareButton.addEventListener("click", function(){
+            shareService.share(
+                "article",
+                articleOptions
+            );
         });
 
         // UI CASHTAG: If the app is opened in the context of a cashtag, show the cashtag in the text box on the app.
@@ -64,7 +85,29 @@ SYMPHONY.remote.hello().then(function(data) {
                     document.getElementById("cashtag").value = cashtag;
                 }
             }
+        } 
+        // SHARE: If the app is opened in the context of an article, show the articleId in the text box on the app.
+        // @TODO(anjana): Refactor this redundant code
+        else if (querystring && /article/.test(querystring)) {
+            var urlParams = querystring.split('&');
+            for (var i = 0; i < urlParams.length; i++) {
+                var pair = urlParams[i].split('=');
+                if(pair[0] == 'article') {
+                    var articleId = pair[1];
+                    document.getElementById("article").value = articleId;
+                }
+            }
         }
-        
+
+        // Implement methods on the application module service
+        helloAppService.implement({
+            // If the menu item is selected, display the About text 
+            menuSelect: function(itemId) {
+                if (itemId == "hello-menu-item") {
+                    document.getElementById("about-hello-world-app").className = "";
+                }
+            }
+        });
+
     }.bind(this))
 }.bind(this));

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -18,27 +18,53 @@
 **/
 
 SYMPHONY.remote.hello().then(function(data) {
-    SYMPHONY.application.connect('hello', ['ui', 'modules', 'applications-nav'], ['hello:module']).then(function(response) {
 
-        //subscribe to system services
+    var themeColor = data.themeV2.name;
+    var themeSize = data.themeV2.size;
+    document.body.className += " " + themeColor + " " + themeSize;
+
+    SYMPHONY.application.connect("hello", ["modules", "applications-nav", "ui", "share"], ["hello:module"]).then(function(response) {
+
+        // The userReferenceId is an anonymized random string that can be used for uniquely identifying users.
+        // The userReferenceId persists until the application is uninstalled by the user. 
+        // If the application is reinstalled, the userReferenceId will change.
         var userId = response.userReferenceId;
-        var uiService = SYMPHONY.services.subscribe('ui');
-        var navService = SYMPHONY.services.subscribe('applications-nav');
-        var modulesService = SYMPHONY.services.subscribe('modules');
+        
+        // Subscribe to Symphony's services
+        var modulesService = SYMPHONY.services.subscribe("modules");
+        var navService = SYMPHONY.services.subscribe("applications-nav");
+        var uiService = SYMPHONY.services.subscribe("ui");
+        var shareService = SYMPHONY.services.subscribe("share");
 
-        //subscribe to the service we created in the controller.js file
+        // Subscribe to our own local service
         var controllerService = SYMPHONY.services.subscribe('hello:controller');
 
-        //bind a click event handler
+        // LEFT NAV: Update the left navigation item's badge count when the "Increment Unread Badge Count" button is clicked using the navService's count method.
         var button = document.getElementById("increment");
+        var count = 0;
+        // Bind a click event handler
         button.addEventListener("click", function(){
-            //invoke the nav service to increment the badge count on the left nav
-            navService.count("hello-nav", 12);
+            count++;
+            navService.count("hello-nav", count);
         });
 
-        //if entering the app via clicking on a cashtag hovercard then log out the URL param
-        if (window.location.search && /cashtag/.test(window.location.search)) {
-            document.getElementById("cashtag").innerHTML =  "URL parameters: " + window.location.search;
+        // UI CASHTAG: If the app is opened in the context of a cashtag, show the cashtag in the text box on the app.
+        // window.location.search returns the querystring part of a URL. Use substring to omit the leading ?.
+        var querystring = window.location.search.substring(1);
+        // Use regex to check if the querystring includes "cashtag"
+        if (querystring && /cashtag/.test(querystring)) {
+            // Split the querystring into a list of pairs
+            var urlParams = querystring.split('&');
+            for (var i = 0; i < urlParams.length; i++) {
+                var pair = urlParams[i].split('=');
+                // Check if the key of one of the pairs is cashtag (there should always be such a pair)
+                if(pair[0] == 'cashtag') {
+                    // Use substring to omit the leading "%24" (url encoding of $)
+                    var cashtag = pair[1].substring(3);
+                    document.getElementById("cashtag").value = cashtag;
+                }
+            }
         }
+        
     }.bind(this))
 }.bind(this));

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -26,7 +26,8 @@ SYMPHONY.remote.hello().then(function(data) {
     // Set the theme of the app module
     var themeColor = data.themeV2.name;
     var themeSize = data.themeV2.size;
-    document.body.className += " " + themeColor + " " + themeSize;
+    // You must add the symphony-external-app class to the body element
+    document.body.className = "symphony-external-app " + themeColor + " " + themeSize;
 
     SYMPHONY.application.connect("hello", ["modules", "applications-nav", "ui", "share"], ["hello:app"]).then(function(response) {
 
@@ -40,6 +41,15 @@ SYMPHONY.remote.hello().then(function(data) {
         var navService = SYMPHONY.services.subscribe("applications-nav");
         var uiService = SYMPHONY.services.subscribe("ui");
         var shareService = SYMPHONY.services.subscribe("share");
+
+        // UI: Listen for theme change events
+        uiService.listen("themeChangeV2", function() {
+            SYMPHONY.remote.hello().then(function(data) {
+                themeColor = data.themeV2.name;
+                themeSize = data.themeV2.size;
+                document.body.className = "symphony-external-app " + themeColor + " " + themeSize;
+            });
+        });
 
         // MODULE: Add a menu item to our module
         modulesService.addMenuItem("hello", "About Hello World App", "hello-menu-item");

--- a/src/javascript/controller.js
+++ b/src/javascript/controller.js
@@ -17,9 +17,9 @@
 * under the License.
 **/
 
-// Create our own local service
+// Create our own local controller service.
 // We have namespaced local services with "hello:"
-var helloService = SYMPHONY.services.register("hello:controller");
+var helloControllerService = SYMPHONY.services.register("hello:controller");
 
 SYMPHONY.remote.hello().then(function(data) {
 
@@ -51,13 +51,16 @@ SYMPHONY.remote.hello().then(function(data) {
         uiService.registerExtension("cashtag", "hello-cashtag", "hello:controller", {label: "Cashtag Link"});
         uiService.registerExtension("settings", "hello-settings", "hello:controller", {label: "Settings Link"});
 
+        // SHARE: Set the controller that implements the "link" method invoked when shared articles are clicked on.
+        shareService.handleLink("article", "hello:controller");
 
         // Implement some methods on our local service. These will be invoked by user actions.
-        helloService.implement({
+        helloControllerService.implement({
 
             // LEFT NAV & MODULE: When the left navigation item is clicked on, invoke Symphony's module service to show our application in the grid
             select: function(id) {
                 modulesService.show("hello", {title: "Hello World App"}, "hello:controller", "https://localhost:4000/app.html", {
+                    // You must specify canFloat in the module options so that the module can be pinned
                     "canFloat": true,
                 });
             },
@@ -76,14 +79,31 @@ SYMPHONY.remote.hello().then(function(data) {
                     // Open our app in the context of the cashtag:
                     // Put the cashtag in the module title.
                     // Include the cashtag in the URL parameters.
-                    console.log('Cashtag link was clicked.');
                     var cashtag = payload.entity.name;
                     var moduleTitle = "Hello World App: " + cashtag;
-                    modulesService.show("hello", {title: moduleTitle}, "hello:controller", "https://localhost:4000/app.html?cashtag=" + cashtag, {});
+                    modulesService.show("hello-cashtag", {title: moduleTitle}, "hello:controller", "https://localhost:4000/app.html?cashtag=" + cashtag, {
+                        "canFloat": true,
+                        // Use parentModuleId to open a new module without closing the original module ("hello")
+                        "parentModuleId": "hello"
+                    });
                 } else if (uiClass == "settings") {
                     console.log('Settings link was clicked.')
                 }
                 console.dir(payload);
+            },
+
+            // SHARE: Open our app in the context of an article:
+            // Put the article in the moudle title.
+            // Include the article in the URL parameters.
+            link: function(type, articleId) {
+                if(type == "article") {
+                    var moduleTitle = "Hello World App: " + articleId;
+                    modulesService.show("hello-article", {title: moduleTitle}, "hello:controller", "https://localhost:4000/app.html?article=" + articleId, {
+                        "canFloat": true,
+                        // Use parentModuleId to open a new module without closing the original module ("hello")
+                        "parentModuleId": "hello"
+                    });
+                }    
             }
 
         });

--- a/src/javascript/controller.js
+++ b/src/javascript/controller.js
@@ -21,6 +21,7 @@
 // We have namespaced local services with "hello:"
 var helloControllerService = SYMPHONY.services.register("hello:controller");
 
+// All Symphony services are namespaced with SYMPHONY
 SYMPHONY.remote.hello().then(function(data) {
 
     // Register our application with the Symphony client:
@@ -63,6 +64,8 @@ SYMPHONY.remote.hello().then(function(data) {
                     // You must specify canFloat in the module options so that the module can be pinned
                     "canFloat": true,
                 });
+                // Focus the module after it is shown
+                modulesService.focus("hello");
             },
 
             // UI: Execute the following when UI extensions are clicked.
@@ -86,6 +89,7 @@ SYMPHONY.remote.hello().then(function(data) {
                         // Use parentModuleId to open a new module without closing the original module ("hello")
                         "parentModuleId": "hello"
                     });
+                    modulesService.focus("hello-cashtag");
                 } else if (uiClass == "settings") {
                     console.log('Settings link was clicked.')
                 }
@@ -103,6 +107,7 @@ SYMPHONY.remote.hello().then(function(data) {
                         // Use parentModuleId to open a new module without closing the original module ("hello")
                         "parentModuleId": "hello"
                     });
+                    modulesService.focus("hello-article");
                 }    
             }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -16,8 +16,3 @@
 * specific language governing permissions and limitations
 * under the License.
 **/
-
-body {
-    background: green;
-    font-size: 2rem;
-}


### PR DESCRIPTION
- Consistency: app, left nav item, module names
- Separate controller and app services
- Theming and responding to theme change
- Left nav increment counter
- Share example - article with id
- Make cashtag view neater - module title and input text box with parsed cashtag from url params
- Menu item on app module
- Pinning app module
- Parent for app module (opening a second app module)
- Registering extensions on IMs/MIMs/hashtags/settings
