### PR TITLE
remove unused jquery dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,5 @@
     "style-loader": "^0.13.0",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1"
-  },
-  "dependencies": {
-    "jquery": "^3.2.1"
   }
 }

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -21,9 +21,6 @@
 // We have namespaced local services with "hello:"
 var helloAppService = SYMPHONY.services.register("hello:app");
 
-
-var $ = require('jquery');
-
 SYMPHONY.remote.hello().then(function(data) {
 
     // Set the theme of the app module


### PR DESCRIPTION
While reading the demo code, I noticed that the import from jquery was useless.

I'm guessing that you're trying to demo a vanilla.js example so having no explicit dependency in  `package.json` looks best.