### PR TITLE
Fix: render method was not returning entityInstanceId

### DIFF
--- a/src/javascript/controller.js
+++ b/src/javascript/controller.js
@@ -236,6 +236,7 @@ SYMPHONY.remote.hello().then(function(data) {
                 }
                 return {
                     // Use a custom template to utilise data sent with the message in entityData in our messageML message
+                    entityInstanceId: entityData.instanceId,
                     template: template,
                     data: {
                         years: "" + diff.yrs,


### PR DESCRIPTION
Since the render method of the entity renderer service needs to return an entityInstanceId, dynamic rendering was not working because it was sending undefined to the Entity Service update method.